### PR TITLE
chore: remove slack and service reporting URLs from settings.example.…

### DIFF
--- a/settings.example.json
+++ b/settings.example.json
@@ -40,8 +40,6 @@
     "file_descriptors": 40960
   },
   "reporting": {
-    "slack_url": "https://slack-reporting-url",
-    "service_url": "https://powerloom-reporting-url",
     "telegram_url": "https://telegram-reporting-url",
     "telegram_chat_id": "telegram-chat-id",
     "min_reporting_interval": 120


### PR DESCRIPTION
<!-- Please create (if there is not one yet) a issue before sending a PR -->
<!-- Add issue number (Eg: fixes #123) -->
<!-- Always provide changes in existing tests or new tests -->

Fixes #9

### Checklist
- [x] My branch is up-to-date with upstream/main branch.
- [x] Everything works and tested for major version of Python/NodeJS/Go and above.
- [x] I ran pre-commit checks against my changes.
- [x] I've written tests against my changes and all the current present tests are passing.

### Current behaviour
The `settings.example.json` file has unused configs for the slack reporting url and the internal ping url.

### New expected behaviour
The unused config fields have been removed.

### Change logs

<!-- #### Added -->
<!-- Edit these points below to describe the new features added with this PR -->
<!-- - Feature 1 -->
<!-- - Feature 2 -->


<!-- #### Changed -->
<!-- Edit these points below to describe the changes made in existing functionality with this PR -->
<!-- - Change 1 -->
<!-- - Change 1 -->


<!-- #### Fixed -->
<!-- Edit these points below to describe the bug fixes made with this PR -->
<!-- - Bug 1 -->


#### Removed
- removed the `slack_url` and `service_url` from the reporting config in `settings.example.json`

## Deployment Instructions
No changes
